### PR TITLE
Added composer example for querying the Commerce Signals API for signals.

### DIFF
--- a/composer/composer.json
+++ b/composer/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "commercesignals/csapi-php-demo",
+    "authors": [
+        {
+            "name": "Parker Vaughn",
+            "email": "parker@commercesignals.com"
+        }
+    ],
+    "require": {
+        "commercesignals/csapi-php": "dev-master"
+    }
+}

--- a/composer/composer.lock
+++ b/composer/composer.lock
@@ -1,0 +1,66 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2e26733c00d8125f5d20f702e425ab0d",
+    "packages": [
+        {
+            "name": "commercesignals/csapi-php",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commercesignals/csapi-php.git",
+                "reference": "17eac199260a24f0547d1d237c92efe5512090b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commercesignals/csapi-php/zipball/17eac199260a24f0547d1d237c92efe5512090b8",
+                "reference": "17eac199260a24f0547d1d237c92efe5512090b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "internations/http-mock": "^0.8.1",
+                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/phpunit": "5.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CommerceSignals\\": "src/CommerceSignals"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Corey Wilson",
+                    "email": "support@commercesignals.com",
+                    "homepage": "https://www.commercesignals.com"
+                }
+            ],
+            "description": "API client library to work with the Commerce Signals platform.",
+            "keywords": [
+                "api",
+                "library"
+            ],
+            "time": "2017-04-05 18:47:09"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "commercesignals/csapi-php": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer/signals.php
+++ b/composer/signals.php
@@ -1,0 +1,58 @@
+<?php
+
+// Use Composer's autoload function to require all api namespaces
+require_once 'vendor/autoload.php';
+
+const CERT_FILE_NAME = 'my-api-key-private-cert.pem';
+const API_KEY = '0a00017c-5b42-1433-815b-449576ab0007';
+const API_BASE = 'https://api.commercesignals.com/';
+
+$cert = file_get_contents(__DIR__ . '/' . CERT_FILE_NAME);
+
+$api = new CommerceSignals\API(API_BASE, [
+  'apiKey' => API_KEY,
+  'cert' => $cert
+]);
+
+// Get a list of all available signals
+$signals = $api->signals()
+              ->get();
+
+
+// Get a list of all signal requests
+$signalId = '0a000367-564f-144e-8156-4f3a97e707a1';
+
+$requests = $api->signals($signalId)
+              ->requests()
+              ->get();
+
+
+// Get the results from a signal request (raw results from the data source)
+$requestId = '0a00017c-5aac-1195-815a-ae99350700b9';
+
+$results = $api->signals($signalId)
+              ->requests($requestId)
+              ->results()
+              ->get();
+
+
+// Get the results and include the summary details (data shown on dashboard results)
+$results = $api->signals($signalId)
+              ->requests($requestId)
+              ->results()
+              ->get(['summarize' => true]);
+
+
+// Get the merchants that are available for a given signal.  The isAuthorized flag will
+// be set to 1 for merchants that have been approved to be used with a given signal
+$merchants = $api->signals($signalId)
+              ->merchants()
+              ->get();
+
+
+// Get a specific merchant for a signal
+$merchantId = '0a000367-564f-144e-8632-4f349c5a00c9';
+
+$merchants = $api->signals($signalId)
+              ->merchants($merchantId)
+              ->get();


### PR DESCRIPTION
This adds an example using composer and composer's autoload to authenticate and query against the CS API